### PR TITLE
Fix hook when `buffer-file-name` is nil

### DIFF
--- a/yatemplate.el
+++ b/yatemplate.el
@@ -141,7 +141,7 @@ Particularly useful when combined with `.dir-locals.el'.")
 ;;; Hooks
 (defun yatemplate--find-file-hook ()
   "Set yatemplate files `snippet-mode' to be able to test."
-  (when (file-in-directory-p buffer-file-name yatemplate-dir)
+  (when (and buffer-file-name (file-in-directory-p buffer-file-name yatemplate-dir))
     (let ((mode major-mode))
       (snippet-mode)
       (set (make-local-variable 'yas--guessed-modes) (list mode)))))
@@ -149,7 +149,7 @@ Particularly useful when combined with `.dir-locals.el'.")
 
 (defun yatemplate--after-save-hook ()
   "Set `auto-insert-alist' after saving yatemplate files."
-  (when (file-in-directory-p buffer-file-name yatemplate-dir)
+  (when (and buffer-file-name (file-in-directory-p buffer-file-name yatemplate-dir))
     (yatemplate-fill-alist)))
 (add-hook 'after-save-hook 'yatemplate--after-save-hook)
 

--- a/yatemplate.el
+++ b/yatemplate.el
@@ -156,8 +156,8 @@ Particularly useful when combined with `.dir-locals.el'.")
 (defun yatemplate-unload-function ()
   "Unload function for yatemplate."
   (interactive)
-  (remove-hook 'find-file-hook yatemplate--find-file-hook)
-  (remove-hook 'after-save-hook yatemplate--after-save-hook)
+  (remove-hook 'find-file-hook 'yatemplate--find-file-hook)
+  (remove-hook 'after-save-hook 'yatemplate--after-save-hook)
   (yatemplate-remove-old-yatemplates-from-alist))
 
 (provide 'yatemplate)


### PR DESCRIPTION
This is a fix for #14 it adds a check to see if `buffer-file-name` is defined before trying to use it. I see this as the solution as we can't control for which files these hooks will run.

Also fix the `yatemplate-unload-function`, when it tried to remove the hooks it used undefined variable references instead of referring to the functions.

I am not sure if these are things that worked differently in older emacs versions, but at least in the latest version I run into these issues.