### PR TITLE
yatemplate-unload-function: Return nil

### DIFF
--- a/yatemplate-tests.el
+++ b/yatemplate-tests.el
@@ -151,5 +151,9 @@
  (after-each
   (delete-directory yatemplate-toplevel-test-dir t)))
 
+(describe "yatemplate-unload-function"
+  (it "should return nil"
+      (expect (yatemplate-unload-function) :to-equal nil)))
+
 (provide 'test-yatemplate)
 ;;; test-yatemplate.el ends here

--- a/yatemplate.el
+++ b/yatemplate.el
@@ -145,7 +145,8 @@ Particularly useful when combined with `.dir-locals.el'.")
         (cl-remove-if
          (lambda (pair)
            (ignore-errors (eq 'yatemplate-expand-yas-buffer (aref (cdr pair) 1))))
-         auto-insert-alist)))
+         auto-insert-alist))
+  nil)
 
 ;;; Hooks
 (defun yatemplate--find-file-hook ()


### PR DESCRIPTION
Instead of the value returned by
`yatemplate-remove-old-yatemplates-from-alist', aka the return value of
`setq'.